### PR TITLE
gnrc_priority_pktqueue: simplify API

### DIFF
--- a/sys/include/net/gnrc/priority_pktqueue.h
+++ b/sys/include/net/gnrc/priority_pktqueue.h
@@ -30,15 +30,33 @@
 extern "C" {
 #endif
 
-typedef priority_queue_node_t packet_queue_node_t;
+typedef struct gnrc_priority_pktqueue_node {
+    struct gnrc_priority_pktqueue_node *next;   /**< next queue node */
+    uint32_t priority;                          /**< queue node priority */
+    gnrc_pktsnip_t *pkt;                        /**< queue node data */
+} gnrc_priority_pktqueue_node_t;
 
 /* TODO: Description */
-typedef struct {
-    priority_queue_t queue;
-    packet_queue_node_t* buffer;
-    size_t buffer_size;
-} gnrc_priority_pktqueue_t;
+typedef priority_queue_t gnrc_priority_pktqueue_t;
 
+#define PRIORITY_PKTQUEUE_NODE_INIT(priority, pkt) { NULL, priority, pkt }
+
+static inline void priority_pktqueue_node_init(gnrc_priority_pktqueue_node_t *node,
+                                               uint32_t priority,
+                                               gnrc_pktsnip_t *pkt)
+{
+    node->next = NULL;
+    node->priority = priority;
+    node->pkt = pkt;
+}
+
+#define PRIORITY_QUEUE_INIT { NULL }
+
+static inline void priority_pktqueue_init(gnrc_priority_pktqueue_t *q)
+{
+    gnrc_priority_pktqueue_t qn = PRIORITY_PKTQUEUE_NODE_INIT;
+    *q = qn;
+}
 
 static inline uint32_t priority_pktqueue_length(gnrc_priority_pktqueue_t *q)
 {
@@ -64,12 +82,7 @@ gnrc_pktsnip_t* priority_pktqueue_pop(gnrc_priority_pktqueue_t* q);
 gnrc_pktsnip_t* priority_pktqueue_head(gnrc_priority_pktqueue_t* q);
 
 packet_queue_node_t* priority_pktqueue_push(gnrc_priority_pktqueue_t* q,
-                                       gnrc_pktsnip_t* snip,
-                                       uint32_t priority);
-
-void priority_pktqueue_init(gnrc_priority_pktqueue_t* q,
-                       packet_queue_node_t buffer[],
-                       size_t buffer_size);
+                                            gnrc_priority_pktqueue_node_t *node);
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/priority_pktqueue/priority_pktqueue.c
+++ b/sys/net/gnrc/priority_pktqueue/priority_pktqueue.c
@@ -19,51 +19,16 @@
  * @}
  */
 
-#include <net/gnrc.h>
+#include "net/gnrc/pktbuf.h"
 #include <net/gnrc/priority_pktqueue.h>
 
 /******************************************************************************/
 
-static packet_queue_node_t* _alloc_node(gnrc_priority_pktqueue_t* q, gnrc_pktsnip_t *pkt)
-{
-    assert(q != NULL);
-    assert(q->buffer != NULL);
-    assert(q->buffer_size > 0);
-    assert(sizeof(unsigned int) == sizeof(gnrc_pktsnip_t*));
-
-    for (size_t i = 0; i < q->buffer_size; i++) {
-        if( (q->buffer[i].data == 0) &&
-            (q->buffer[i].next == NULL))
-        {
-            q->buffer[i].data = (unsigned int) pkt;
-            return &(q->buffer[i]);
-        }
-    }
-
-    return NULL;
-}
-
-/******************************************************************************/
-
-static inline void _free_node(packet_queue_node_t *node)
+static inline void _free_node(gnrc_priority_pktqueue_node_t *node)
 {
     assert(node != NULL);
 
-    node->data = 0;
-    node->next = NULL;
-}
-
-/******************************************************************************/
-
-void priority_pktqueue_init(gnrc_priority_pktqueue_t* q, packet_queue_node_t buffer[], size_t buffer_size)
-{
-    assert(q != NULL);
-    assert(buffer != NULL);
-    assert(buffer_size > 0);
-
-    q->buffer = buffer;
-    q->buffer_size = buffer_size;
-    q->queue.first = NULL;
+    priority_queue_node_init((priority_queue_node_t *)node);
 }
 
 /******************************************************************************/
@@ -72,7 +37,7 @@ gnrc_pktsnip_t* priority_pktqueue_pop(gnrc_priority_pktqueue_t* q)
 {
     if(!q || (priority_pktqueue_length(q) == 0))
         return NULL;
-    packet_queue_node_t* head = priority_queue_remove_head(&(q->queue));
+    priority_queue_node_t *head = priority_queue_remove_head(q);
     gnrc_pktsnip_t* pkt = (gnrc_pktsnip_t*) head->data;
     _free_node(head);
     return pkt;
@@ -84,24 +49,19 @@ gnrc_pktsnip_t* priority_pktqueue_head(gnrc_priority_pktqueue_t* q)
 {
     if(!q || (priority_pktqueue_length(q) == 0))
         return NULL;
-    return (gnrc_pktsnip_t*) q->queue.first->data;
+    return (gnrc_pktsnip_t *)q->first->data;
 }
 /******************************************************************************/
 
-packet_queue_node_t*
-priority_pktqueue_push(gnrc_priority_pktqueue_t* q, gnrc_pktsnip_t* snip, uint32_t priority)
+void priority_pktqueue_push(gnrc_priority_pktqueue_t* q,
+                            gnrc_priority_pktqueue_node_t *node)
 {
     assert(q != NULL);
-    assert(snip != NULL);
+    assert(node != NULL);
+    assert(node->pkt != NULL);
+    assert(sizeof(unsigned int) == sizeof(gnrc_pktsnip_t));
 
-    packet_queue_node_t* node = _alloc_node(q, snip);
-
-    if(node)
-    {
-        node->priority = priority;
-        priority_queue_add(&(q->queue), node);
-    }
-    return node;
+    priority_queue_add(q, (priority_queue_node_t *)node);
 }
 
 /******************************************************************************/
@@ -111,10 +71,10 @@ void priority_pktqueue_flush(gnrc_priority_pktqueue_t* q)
     if(priority_pktqueue_length(q) == 0)
         return;
 
-    packet_queue_node_t* node;
-    while( (node = priority_queue_remove_head(&(q->queue))) )
+    gnrc_priority_pktqueue_node_t* node;
+    while( (node = (gnrc_priority_pktqueue_node_t *)priority_queue_remove_head(q)) )
     {
-        gnrc_pktbuf_release((gnrc_pktsnip_t*) node->data);
+        gnrc_pktbuf_release(node->pkt);
         _free_node(node);
     }
 }


### PR DESCRIPTION
There is a lot simplification possible, if you do not add the pool of nodes to the queue and let the "user" handle it externally. One would now go to allocate a node like this (sometimes a node allocated somewhere in a function allocated might already be enough for an application so a central array would be overkill). Also there are a lot of style issues that I did not fix with this PR that need fixing before we can merge https://github.com/RIOT-OS/RIOT/pull/5950!

With this change one would now push a packet `pkt` to the queue `q` as follows:

``` C
gnrc_priority_pktqueue_node_t *some_node = get_somewhere();
priority_pktqueue_node_init(some_node, priority, pkt);
priority_pktqueue_push(&q, some_node);
```

Style-note: the functions need `gnrc_` prefixing of course ;-)
